### PR TITLE
Improved Buy Neutral mod

### DIFF
--- a/BuyNeutralMod/Client_PresentCommercePurchaseUI.lua
+++ b/BuyNeutralMod/Client_PresentCommercePurchaseUI.lua
@@ -3,7 +3,7 @@ require('Client_PresentMenuUI');
 function Client_PresentCommercePurchaseUI(rootParent, game, close)
 	local vert = UI.CreateVerticalLayoutGroup(rootParent);
 	UI.CreateLabel(vert).SetText("You can try to purchase neutral territories for " .. Mod.Settings.CostPerNeutralArmy .. " per army on that territory").SetColor("#DDDDDD");
-	CreateButton(vert).SetText("Purchase territory").SetColor("#00FF05").SetOnClick(function()
+	UI.CreateButton(vert).SetText("Purchase territory").SetColor("#00FF05").SetOnClick(function()
 			-- Call Client_PresentMenuUI that will handle everything else
 			game.CreateDialog(Client_PresentMenuUI); 
 			close();

--- a/BuyNeutralMod/Client_PresentCommercePurchaseUI.lua
+++ b/BuyNeutralMod/Client_PresentCommercePurchaseUI.lua
@@ -1,0 +1,6 @@
+require('Client_PresentMenuUI');
+
+function Client_PresentCommercePurchaseUI(rootParent, game, close)
+	game.CreateDialog(Client_PresentMenuUI);
+end
+

--- a/BuyNeutralMod/Client_PresentCommercePurchaseUI.lua
+++ b/BuyNeutralMod/Client_PresentCommercePurchaseUI.lua
@@ -1,6 +1,12 @@
 require('Client_PresentMenuUI');
 
 function Client_PresentCommercePurchaseUI(rootParent, game, close)
-	game.CreateDialog(Client_PresentMenuUI);
+	local vert = UI.CreateVerticalLayoutGroup(rootParent);
+	UI.CreateLabel(vert).SetText("You can try to purchase neutral territories for " .. Mod.Settings.CostPerNeutralArmy .. " per army on that territory").SetColor("#DDDDDD");
+	CreateButton(vert).SetText("Purchase territory").SetColor("#00FF05").SetOnClick(function()
+			-- Call Client_PresentMenuUI that will handle everything else
+			game.CreateDialog(Client_PresentMenuUI); 
+			close();
+		end);
 end
 

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -165,6 +165,7 @@ function binarySearchNumberInArray(arr, n, l, r)
 end
 
 function binaryInsertNumber(arr, n, l, r)
+	if #arr == 0 then table.insert(arr, n);
 	if l == nil or r == nil then
 		l = 1;
 		r = #arr;

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -32,8 +32,7 @@ function showMain()
 	
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
 	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
-	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false);
-	requestNewTerritoryButton.SetOnClick(function()
+	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).(function()
 			showMain();
 		end);
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -43,8 +43,8 @@ function TargetTerritoryClicked(terrDetails)
 	end
 	
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
-	print(terr.FogLevel, WL.StandingFogLevel.Visible);
-	if terr.FogLevel == WL.StandingFogLevel.Visible then
+	
+	if terr.FogLevel ~= WL.StandingFogLevel.Visible then
 		wrongInputLabel.SetText("The territory must be fully visible for you to be able to buy it");
 		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 		return;

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -23,17 +23,17 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 end
 
 function showMain()
-	territoryLabel = UI.CreateLabel(vert).SetText("Click the neutral territory that you want to buy");
+	territoryLabel = UI.CreateLabel(vert).SetText("Click the neutral territory that you want to buy").SetColor("#DDDDDD");
 	UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 	
 	wrongInputLabel = UI.CreateLabel(vert).SetColor("#CC0000");
 	
 	
-	CostLabel = UI.CreateLabel(vert).SetText(" ");
+	CostLabel = UI.CreateLabel(vert).SetText(" ").SetColor("#DDDDDD");
 	
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
-	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
-	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).SetOnClick(function()
+	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false).SetColor("#00FF05");
+	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).SetColor("#23A0FF").SetOnClick(function()
 			UI.Destroy(vert);
 			vert = UI.CreateVerticalLayoutGroup(root);
 			showMain();

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -43,7 +43,7 @@ function TargetTerritoryClicked(terrDetails)
 	end
 	
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
-	
+	print(terr.FogLevel, WL.StandingFogLevel.Visible);
 	if terr.FogLevel == WL.StandingFogLevel.Visible then
 		wrongInputLabel.SetText("The territory must be fully visible for you to be able to buy it");
 		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
@@ -56,7 +56,7 @@ function TargetTerritoryClicked(terrDetails)
 		return;
 	end
 	
-	if #terr.NumArmies.SpecialUnits == 0 then
+	if #terr.NumArmies.SpecialUnits > 0 then
 		wrongInputLabel.SetText("You cannot buy territories that have special units");
 		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 		return;

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -22,7 +22,7 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 	territoryLabel = UI.CreateLabel(row1).SetText("Click the neutral territory that you want to buy");
 	UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 	
-	wrongInputLabel = UI.CreateLabel(vert).SetColor("#AA0000");
+	wrongInputLabel = UI.CreateLabel(vert).SetColor("#CC0000");
 
 
 	CostLabel = UI.CreateLabel(vert).SetText(" ");
@@ -41,21 +41,24 @@ function TargetTerritoryClicked(terrDetails)
 		-- We cannot gather information from nil, but we do want a territory to be clicked
 		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 	end
-
+	
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
 	
 	if terr.FogLevel == WL.StandingFogLevel.Visible then
 		wrongInputLabel.SetText("The territory must be fully visible for you to be able to buy it");
+		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 		return;
 	end
-
+	
 	if terr.OwnerPlayerID == WL.PlayerID.Neutral then
 		wrongInputLabel.SetText("You cannot buy a non-neutral territory");
+		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 		return;
 	end
-
+	
 	if #terr.NumArmies.SpecialUnits == 0 then
 		wrongInputLabel.SetText("You cannot buy territories that have special units");
+		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 		return;
 	end
 

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -28,12 +28,12 @@ function showMain()
 	
 	wrongInputLabel = UI.CreateLabel(vert).SetColor("#CC0000");
 	
-	
 	CostLabel = UI.CreateLabel(vert).SetText(" ").SetColor("#DDDDDD");
 	
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
 	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false).SetColor("#00FF05");
-	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).SetColor("#23A0FF").SetOnClick(function()
+	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Reselect territory").SetInteractable(false).SetColor("#23A0FF").SetOnClick(function()
+			-- Reset the window
 			UI.Destroy(vert);
 			vert = UI.CreateVerticalLayoutGroup(root);
 			showMain();
@@ -51,6 +51,10 @@ function TargetTerritoryClicked(terrDetails)
 		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 	end
 	
+	if Game == nil then
+		-- An error check that I got from time to time
+		return WL.CancelClickIntercept;
+	end
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
 
 	if terr.FogLevel ~= WL.StandingFogLevel.Visible then

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -115,6 +115,9 @@ function SubmitClicked()
 	local order = WL.GameOrderCustom.Create(Game.Us.ID, msg, payload, { [WL.ResourceType.Gold] = Cost } );
 
 	local orders = Game.Orders;
-	table.insert(orders, order);
+	-- I will be placing the order in the Buy phase
+	for i, v in pairs(WL.TurnPhase) do
+		print(i, v);
+	end
 	Game.Orders = orders;
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -150,7 +150,7 @@ function SubmitClicked()
     if index == 0 then index = #orders + 1; end
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
-	for i, v in ipairs(requestNewTerritoryButton.readableKeys) do
+	for _, v in pairs(requestNewTerritoryButton) do
 		print(v, requestNewTerritoryButton[v]);
 	end
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -150,7 +150,7 @@ function SubmitClicked()
     if index == 0 then index = #orders + 1; end
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
-	for _, v in pairs(requestNewTerritoryButton) do
-		print(v, requestNewTerritoryButton[v]);
+	for i, v in pairs(requestNewTerritoryButton) do
+		print(i, v);
 	end
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -22,10 +22,9 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 	purchaseRequests = {};
 	for _, order in ipairs(game.Orders) do
 		if (order.proxyType == 'GameOrderCustom' and startsWith(order.Payload, 'BuyNeutral_')) then
-			table.insert(tonumber(string.sub(order.Payload, 12)));
+			table.insert(purchaseRequests, tonumber(string.sub(order.Payload, 12)));
 		end
 	end
-	table.sort(purchaseRequests);
 
 	printArray(purchaseRequests);
 
@@ -69,7 +68,7 @@ function TargetTerritoryClicked(terrDetails)
 
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
 
-	if binarySearchNumberInArray(purchaseRequests, terrDetails.ID) then
+	if valueInTable(purchaseRequests, terrDetails.ID) then
 		wrongInputLabel.SetText("You already have a purchase request for this territory");
 		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 		return;
@@ -143,46 +142,8 @@ function SubmitClicked()
     if index == 0 then index = #orders + 1; end
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
-	binaryInsertNumber(purchaseRequests, TargetTerritoryID);
+	table.insert(purchaseRequests, TargetTerritoryID);
 	printArray(purchaseRequests);
-end
-
-function binarySearchNumberInArray(arr, n, l, r)
-	if #arr == 0 then return false; end
-	if l == nil or r == nil then
-		l = 1;
-		r = #arr;
-	end
-	if l == r then return arr[l] == n; end
-	local mid = math.floor((r - l) / 2 + l);
-	local midValue = arr[mid];
-	if midValue == n then 
-		return true;
-	elseif midValue > n then
-		return binarySearchNumberInArray(arr, n, l, mid - 1);
-	else
-		return binarySearchNumberInArray(arr, n, mid + 1, r);
-	end
-end
-
-function binaryInsertNumber(arr, n, l, r)
-	if #arr == 0 then table.insert(arr, n); end
-	if l == nil or r == nil then
-		l = 1;
-		r = #arr;
-	end
-	if l == r then
-		table.insert(arr, l, n);
-	end
-	local mid = math.floor((r - l) / 2 + l);
-	local midValue = arr[mid];
-	if midValue == n then 
-		return;
-	elseif midValue > n then 
-		binarySearchNumberInArray(arr, n, l, mid - 1);
-	else 
-		binarySearchNumberInArray(arr, n, mid + 1, r);
-	end
 end
 
 function printArray(arr)

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -27,7 +27,7 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 	CostLabel = UI.CreateLabel(vert).SetText(" ");
 	
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
-	submitButton = UI.CreateButton(vert).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
+	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
 	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).SetOnClick(TargetTerritoryClicked);
 end
 

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -113,16 +113,16 @@ function SubmitClicked()
 
     --Pass a cost to the GameOrderCustom as its fourth argument.  This ensures the game takes the gold away from the player for this order, both on the client and server.
 	-- I will be placing the order in the purchase phase
-	local order = WL.GameOrderCustom.Create(Game.Us.ID, msg, payload, { [WL.ResourceType.Gold] = Cost }, WL.TurnPhase.Purchase);
+	local custom = WL.GameOrderCustom.Create(Game.Us.ID, msg, payload, { [WL.ResourceType.Gold] = Cost }, WL.TurnPhase.Purchase);
 	local orders = Game.Orders;
 	local index = 0;
     for i, order in pairs(orders) do
-        if order.OccursInPhase ~= nil and order.OccursInPhase > order.OccursInPhaseOpt then
+        if order.OccursInPhase ~= nil and order.OccursInPhase > custom.OccursInPhaseOpt then
             index = i;
             break;
         end
     end
     if index == 0 then index = #orders + 1; end
-	table.insert(orders, index, order);
+	table.insert(orders, index, custom);
 	Game.Orders = orders;
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -154,9 +154,13 @@ function binarySearchNumberInArray(arr, n, l, r)
 	end
 	local mid = math.floor((r - l) / 2 + l);
 	local midValue = arr[mid];
-	if midValue == n then return true;
-	elseif midValue > n then return binarySearchNumberInArray(arr, n, l, mid - 1);
-	else return binarySearchNumberInArray(arr, n, mid + 1, r);
+	if midValue == n then 
+		return true;
+	elseif midValue > n then
+		return binarySearchNumberInArray(arr, n, l, mid - 1);
+	else
+		return binarySearchNumberInArray(arr, n, mid + 1, r);
+	end
 end
 
 function binaryInsertNumber(arr, n, l, r)
@@ -169,9 +173,13 @@ function binaryInsertNumber(arr, n, l, r)
 	end
 	local mid = math.floor((r - l) / 2 + l);
 	local midValue = arr[mid];
-	if midValue == n then return;
-	elseif midValue > n then binarySearchNumberInArray(arr, n, l, mid - 1);
-	else binarySearchNumberInArray(arr, n, mid + 1, r);
+	if midValue == n then 
+		return;
+	elseif midValue > n then 
+		binarySearchNumberInArray(arr, n, l, mid - 1);
+	else 
+		binarySearchNumberInArray(arr, n, mid + 1, r);
+	end
 end
 
 function printArray(arr)

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -113,7 +113,7 @@ function SubmitClicked()
 
     --Pass a cost to the GameOrderCustom as its fourth argument.  This ensures the game takes the gold away from the player for this order, both on the client and server.
 	local order = WL.GameOrderCustom.Create(Game.Us.ID, msg, payload, { [WL.ResourceType.Gold] = Cost } );
-	-- I will be placing the order in the Buy phase
+	-- I will be placing the order in the purchase phase
 	order.OccursInPhaseOpt = WL.TurnPhase.Purchase;
 	local orders = Game.Orders;
 	local index = 0;

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -150,5 +150,4 @@ function SubmitClicked()
     if index == 0 then index = #orders + 1; end
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
-	requestNewTerritoryButton.GetIsClicked()();
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -165,7 +165,7 @@ function binarySearchNumberInArray(arr, n, l, r)
 end
 
 function binaryInsertNumber(arr, n, l, r)
-	if #arr == 0 then table.insert(arr, n);
+	if #arr == 0 then table.insert(arr, n); end
 	if l == nil or r == nil then
 		l = 1;
 		r = #arr;

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -154,7 +154,7 @@ function binarySearchNumberInArray(arr, n, l, r)
 	end
 	local mid = math.floor((r - l) / 2 + l);
 	local midValue = arr[mid];
-	if midValue == n then true;
+	if midValue == n then return true;
 	elseif midValue > n then return binarySearchNumberInArray(arr, n, l, mid - 1);
 	else return binarySearchNumberInArray(arr, n, mid + 1, r);
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -26,10 +26,6 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 		end
 	end
 
-	for i, v in pairs(WL.StandingFogLevel) do
-		print(i, v);
-	end
-
 	showMain();
 end
 
@@ -76,20 +72,26 @@ function TargetTerritoryClicked(terrDetails)
 		return;
 	end
 
+	if terr.FogLevel == WL.StandingFogLevel.You then
+		wrongInputLabel.SetText("You cannot purchase a territory you already own");
+		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
+		return;	
+	end
+
 	if terr.FogLevel ~= WL.StandingFogLevel.Visible then
-		wrongInputLabel.SetText("The territory must be fully visible for you to be able to buy it");
+		wrongInputLabel.SetText("The territory must be fully visible for you to be able to purchase it");
 		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 		return;
 	end
 	
 	if terr.OwnerPlayerID ~= WL.PlayerID.Neutral then
-		wrongInputLabel.SetText("You cannot buy a non-neutral territory");
+		wrongInputLabel.SetText("You cannot purchase a non-neutral territory");
 		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 		return;
 	end
 	
 	if #terr.NumArmies.SpecialUnits > 0 then
-		wrongInputLabel.SetText("You cannot buy territories that have special units");
+		wrongInputLabel.SetText("You cannot purchase territories that have special units");
 		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 		return;
 	end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -151,4 +151,5 @@ function SubmitClicked()
     if index == 0 then index = #orders + 1; end
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
+	resetWindow();
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -153,6 +153,7 @@ function binarySearchNumberInArray(arr, n, l, r)
 		l = 1;
 		r = #arr;
 	end
+	if l == r then return arr[l] == n; end
 	local mid = math.floor((r - l) / 2 + l);
 	local midValue = arr[mid];
 	if midValue == n then 

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -147,4 +147,5 @@ function SubmitClicked()
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
 	table.insert(purchaseRequests, TargetTerritoryID);
+	requestNewTerritoryButton.GetIsClicked()();
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -150,5 +150,5 @@ function SubmitClicked()
     if index == 0 then index = #orders + 1; end
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
-	print(type(requestNewTerritoryButton.GetIsClicked()));
+	print(type(requestNewTerritoryButton.GetOnClick()));
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -18,17 +18,17 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 		return;
 	end
 
-	local row1 = UI.CreateHorizontalLayoutGroup(vert);
-	territoryLabel = UI.CreateLabel(row1).SetText("Click the neutral territory that you want to buy");
+	territoryLabel = UI.CreateLabel(vert).SetText("Click the neutral territory that you want to buy");
 	UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 	
 	wrongInputLabel = UI.CreateLabel(vert).SetColor("#CC0000");
-
-
+	
+	
 	CostLabel = UI.CreateLabel(vert).SetText(" ");
 	
+	local row1 = UI.CreateHorizontalLayoutGroup(vert);
 	submitButton = UI.CreateButton(vert).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
-
+	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).SetOnClick(TargetTerritoryClicked);
 end
 
 
@@ -72,6 +72,7 @@ function TargetTerritoryClicked(terrDetails)
 	TargetTerritoryID = terrDetails.ID;
 
 	submitButton.SetInteractable(true);
+	requestNewTerritoryButton.SetInteractable(true);
 end
 
 function SubmitClicked()
@@ -89,7 +90,7 @@ function SubmitClicked()
 	end
 	
 	if (goldHave < Cost) then
-		UI.Alert("You can't afford it.  You have " .. goldHave .. " gold and it costs " .. Cost);
+		UI.Alert("You can't afford it. You have " .. goldHave .. " gold and it costs " .. Cost);
 		return;
 	end
 

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -33,6 +33,8 @@ function showMain()
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
 	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
 	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).SetOnClick(function()
+			UI.Destroy(vert);
+			vert = UI.CreateVerticalLayoutGroup(rootParent);
 			showMain();
 		end);
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -150,4 +150,5 @@ function SubmitClicked()
     if index == 0 then index = #orders + 1; end
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
+	print(type(requestNewTerritoryButton.GetIsClicked()));
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -42,7 +42,7 @@ end
 
 
 function TargetTerritoryClicked(terrDetails)
-	if UI.IsDestroyed(vert) then
+	if UI.IsDestroyed(vert) or Game == nil then
 		-- Dialog was destroyed, so we don't need to intercept the click anymore
 		return WL.CancelClickIntercept; 
 	end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -33,14 +33,15 @@ function showMain()
 	
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
 	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false).SetColor("#00FF05");
-	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Reselect territory").SetInteractable(false).SetColor("#23A0FF").SetOnClick(function()
-			-- Reset the window
-			UI.Destroy(vert);
-			vert = UI.CreateVerticalLayoutGroup(root);
-			showMain();
-		end);
+	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Reselect territory").SetInteractable(false).SetColor("#23A0FF").SetOnClick(resetWindow)
 end
 
+function resetWindow()
+	-- Reset the window
+	UI.Destroy(vert);
+	vert = UI.CreateVerticalLayoutGroup(root);
+	showMain();
+end
 
 function TargetTerritoryClicked(terrDetails)
 	if UI.IsDestroyed(vert) then
@@ -150,9 +151,4 @@ function SubmitClicked()
     if index == 0 then index = #orders + 1; end
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
-	for i, v in pairs(requestNewTerritoryButton) do
-		print(i, v);
-	end
-	local func = requestNewTerritoryButton.GetOnClick();
-	if func ~= nil then func(); end
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -29,7 +29,7 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
 	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
 	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false);
-	requestNewTerritoryButton..SetOnClick(function()
+	requestNewTerritoryButton.SetOnClick(function()
 			UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 			submitButton.SetInteractable(false);
 			requestNewTerritoryButton.SetInteractable(false);

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -55,9 +55,7 @@ function TargetTerritoryClicked(terrDetails)
 		-- An error check that I got from time to time
 		return WL.CancelClickIntercept;
 	end
-	for i, v in pairs(terrDetails) do
-		print(i, v);
-	end
+	print(terrDetails)
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
 
 	if terr.FogLevel ~= WL.StandingFogLevel.Visible then

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -66,6 +66,9 @@ function TargetTerritoryClicked(terrDetails)
 
 	territoryLabel.SetText("Chosen territory: " .. Game.Map.Territories[terrDetails.ID].Name);
 
+	Cost = Mod.Settings.CostPerNeutralArmy * terr.NumArmies.NumArmies;
+	CostLabel.SetText("This territory costs " .. Cost .. " gold");
+
 	TargetTerritoryID = terrDetails.ID;
 
 	submitButton.SetInteractable(true);

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -61,7 +61,7 @@ function TargetTerritoryClicked(terrDetails)
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
 
 	local purchaseRequests = {};
-	for _, order in ipairs(game.Orders) do
+	for _, order in ipairs(Game.Orders) do
 		if order.OccursInPhase ~= nil and order.OccursInPhase > Phase then
 			break;
 		end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -19,23 +19,33 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 	end
 
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
-	UI.CreateLabel(row1).SetText("Purchase territory: ");
-	TargetTerritoryBtn = UI.CreateButton(row1).SetText("Select territory...").SetOnClick(TargetTerritoryClicked);
+	territoryLabel = UI.CreateLabel(row1).SetText("Purchase territory: ");
+	UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 
 
 	CostLabel = UI.CreateLabel(vert).SetText(" ");
 	
-	UI.CreateButton(vert).SetText("Purchase").SetOnClick(SubmitClicked);
+	UI.CreateButton(vert).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
 
 end
 
 
-function TargetTerritoryClicked()
-	local options = map(filter(Game.LatestStanding.Territories, function(t) 
-		return t.FogLevel == WL.StandingFogLevel.Visible and t.OwnerPlayerID == WL.PlayerID.Neutral  --only show unfogged, neutral territories.
-		end), TerritoryButton);
-	UI.PromptFromList("Select the territory you'd like to purchase", options);
+function TargetTerritoryClicked(terrDetails)
+	if UI.IsDestroyed(vert) then
+		-- Dialog was destroyed, so we don't need to intercept the click anymore
+		return WL.CancelClickIntercept; 
+	end
+	if terrDetails == nil then
+		-- We cannot gather information from nil, but we do want a territory to be clicked
+		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
+	end
+
+	local terr = Game.LatestStanding.Territories[terrDetails.ID];
+	for i, v in pairs(WL.FogLevel) do
+		print(i, v);
+	end
 end
+
 function TerritoryButton(terr)
 	local name = Game.Map.Territories[terr.ID].Name;
 	local ret = {};

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -48,14 +48,14 @@ function TargetTerritoryClicked(terrDetails)
 	end
 	if terrDetails == nil then
 		-- We cannot gather information from nil, but we do want a territory to be clicked
-		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
+		return UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 	end
 	
 	if Game == nil then
 		-- An error check that I got from time to time
 		return WL.CancelClickIntercept;
 	end
-	print(terrDetails)
+
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
 
 	if terr.FogLevel ~= WL.StandingFogLevel.Visible then

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -32,7 +32,7 @@ function showMain()
 	
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
 	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
-	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).(function()
+	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).SetOnClick(function()
 			showMain();
 		end);
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -112,9 +112,8 @@ function SubmitClicked()
 	local payload = 'BuyNeutral_' .. TargetTerritoryID;
 
     --Pass a cost to the GameOrderCustom as its fourth argument.  This ensures the game takes the gold away from the player for this order, both on the client and server.
-	local order = WL.GameOrderCustom.Create(Game.Us.ID, msg, payload, { [WL.ResourceType.Gold] = Cost } );
 	-- I will be placing the order in the purchase phase
-	order.OccursInPhaseOpt = WL.TurnPhase.Purchase;
+	local order = WL.GameOrderCustom.Create(Game.Us.ID, msg, payload, { [WL.ResourceType.Gold] = Cost }, WL.TurnPhase.Purchase);
 	local orders = Game.Orders;
 	local index = 0;
     for i, order in pairs(orders) do

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -6,6 +6,7 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 
 	setMaxSize(450, 250);
 
+	root = rootParent;
 	vert = UI.CreateVerticalLayoutGroup(rootParent);
 
 	if (game.Settings.CommerceGame == false) then

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -28,9 +28,12 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 	
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
 	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
-	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).SetOnClick(function()
-					UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
-				end);
+	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false);
+	requestNewTerritoryButton..SetOnClick(function()
+			UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
+			submitButton.SetInteractable(false);
+			requestNewTerritoryButton.SetInteractable(false);
+		end);
 end
 
 

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -55,6 +55,9 @@ function TargetTerritoryClicked(terrDetails)
 		-- An error check that I got from time to time
 		return WL.CancelClickIntercept;
 	end
+	for i, v in pairs(terrDetails) do
+		print(i, v);
+	end
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
 
 	if terr.FogLevel ~= WL.StandingFogLevel.Visible then

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -28,7 +28,9 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 	
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
 	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
-	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).SetOnClick(TargetTerritoryClicked);
+	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).SetOnClick(function()
+					UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
+				end);
 end
 
 

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -113,11 +113,17 @@ function SubmitClicked()
 
     --Pass a cost to the GameOrderCustom as its fourth argument.  This ensures the game takes the gold away from the player for this order, both on the client and server.
 	local order = WL.GameOrderCustom.Create(Game.Us.ID, msg, payload, { [WL.ResourceType.Gold] = Cost } );
-
-	local orders = Game.Orders;
 	-- I will be placing the order in the Buy phase
-	for i, v in pairs(WL.TurnPhase) do
-		print(i, v);
-	end
+	order.OccursInPhaseOpt = WL.TurnPhase.Purchase;
+	local orders = Game.Orders;
+	local index = 0;
+    for i, order in pairs(orders) do
+        if order.OccursInPhase ~= nil and order.OccursInPhase > order.OccursInPhaseOpt then
+            index = i;
+            break;
+        end
+    end
+    if index == 0 then index = #orders + 1; end
+	table.insert(orders, index, order);
 	Game.Orders = orders;
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -150,5 +150,7 @@ function SubmitClicked()
     if index == 0 then index = #orders + 1; end
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
-	print(type(requestNewTerritoryButton.GetOnClick()));
+	for i, v in ipairs(requestNewTerritoryButton.ReadableKeys) do
+		print(v, requestNewTerritoryButton[v]);
+	end
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -35,7 +35,7 @@ function showMain()
 	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
 	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false).SetOnClick(function()
 			UI.Destroy(vert);
-			vert = UI.CreateVerticalLayoutGroup(rootParent);
+			vert = UI.CreateVerticalLayoutGroup(root);
 			showMain();
 		end);
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -18,6 +18,10 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 		return;
 	end
 
+	showMain();
+end
+
+function showMain()
 	territoryLabel = UI.CreateLabel(vert).SetText("Click the neutral territory that you want to buy");
 	UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 	
@@ -30,9 +34,7 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 	submitButton = UI.CreateButton(row1).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
 	requestNewTerritoryButton = UI.CreateButton(row1).SetText("Choose new territory").SetInteractable(false);
 	requestNewTerritoryButton.SetOnClick(function()
-			UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
-			submitButton.SetInteractable(false);
-			requestNewTerritoryButton.SetInteractable(false);
+			showMain();
 		end);
 end
 

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -51,6 +51,8 @@ end
 
 
 function TargetTerritoryClicked(terrDetails)
+
+	printArray(WL.StandingFogLevel);
 	if UI.IsDestroyed(vert) then
 		-- Dialog was destroyed, so we don't need to intercept the click anymore
 		return WL.CancelClickIntercept; 

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -150,7 +150,7 @@ function SubmitClicked()
     if index == 0 then index = #orders + 1; end
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
-	for i, v in ipairs(requestNewTerritoryButton.ReadableKeys) do
+	for i, v in ipairs(requestNewTerritoryButton.readableKeys) do
 		print(v, requestNewTerritoryButton[v]);
 	end
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -26,7 +26,9 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 		end
 	end
 
-	printArray(purchaseRequests);
+	for i, v in pairs(WL.StandingFogLevel) do
+		print(i, v);
+	end
 
 	showMain();
 end
@@ -51,8 +53,6 @@ end
 
 
 function TargetTerritoryClicked(terrDetails)
-
-	printArray(WL.StandingFogLevel);
 	if UI.IsDestroyed(vert) then
 		-- Dialog was destroyed, so we don't need to intercept the click anymore
 		return WL.CancelClickIntercept; 
@@ -145,11 +145,4 @@ function SubmitClicked()
 	table.insert(orders, index, custom);
 	Game.Orders = orders;
 	table.insert(purchaseRequests, TargetTerritoryID);
-	printArray(purchaseRequests);
-end
-
-function printArray(arr)
-	for i, v in ipairs(arr) do
-		print(i, v);
-	end
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -41,7 +41,7 @@ function TargetTerritoryClicked(terrDetails)
 	end
 
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
-	for i, v in pairs(WL.FogLevel) do
+	for i, v in pairs(WL.StandingFogLevel) do
 		print(i, v);
 	end
 end

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -19,13 +19,15 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 	end
 
 	local row1 = UI.CreateHorizontalLayoutGroup(vert);
-	territoryLabel = UI.CreateLabel(row1).SetText("Purchase territory: ");
+	territoryLabel = UI.CreateLabel(row1).SetText("Click the neutral territory that you want to buy");
 	UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
+	
+	wrongInputLabel = UI.CreateLabel(vert).SetColor("#AA0000");
 
 
 	CostLabel = UI.CreateLabel(vert).SetText(" ");
 	
-	UI.CreateButton(vert).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
+	submitButton = UI.CreateButton(vert).SetText("Purchase").SetOnClick(SubmitClicked).SetInteractable(false);
 
 end
 
@@ -41,22 +43,29 @@ function TargetTerritoryClicked(terrDetails)
 	end
 
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
-	for i, v in pairs(WL.StandingFogLevel) do
-		print(i, v);
+	
+	if terr.FogLevel == WL.StandingFogLevel.Visible then
+		wrongInputLabel.SetText("The territory must be fully visible for you to be able to buy it");
+		return;
 	end
-end
 
-function TerritoryButton(terr)
-	local name = Game.Map.Territories[terr.ID].Name;
-	local ret = {};
-	ret["text"] = name;
-	ret["selected"] = function()
-		TargetTerritoryBtn.SetText(name);
-		TargetTerritoryID = terr.ID;
-		Cost = terr.NumArmies.NumArmies * Mod.Settings.CostPerNeutralArmy;
-		CostLabel.SetText("Cost = " .. Cost .. " gold");
+	if terr.OwnerPlayerID == WL.PlayerID.Neutral then
+		wrongInputLabel.SetText("You cannot buy a non-neutral territory");
+		return;
 	end
-	return ret;
+
+	if #terr.NumArmies.SpecialUnits == 0 then
+		wrongInputLabel.SetText("You cannot buy territories that have special units");
+		return;
+	end
+
+	wrongInputLabel.SetText(" ");
+
+	territoryLabel.SetText("Chosen territory: " .. Game.Map.Territories[terrDetails.ID].Name);
+
+	TargetTerritoryID = terrDetails.ID;
+
+	submitButton.SetInteractable(true);
 end
 
 function SubmitClicked()

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -43,14 +43,14 @@ function TargetTerritoryClicked(terrDetails)
 	end
 	
 	local terr = Game.LatestStanding.Territories[terrDetails.ID];
-	
+
 	if terr.FogLevel ~= WL.StandingFogLevel.Visible then
 		wrongInputLabel.SetText("The territory must be fully visible for you to be able to buy it");
 		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 		return;
 	end
 	
-	if terr.OwnerPlayerID == WL.PlayerID.Neutral then
+	if terr.OwnerPlayerID ~= WL.PlayerID.Neutral then
 		wrongInputLabel.SetText("You cannot buy a non-neutral territory");
 		UI.InterceptNextTerritoryClick(TargetTerritoryClicked);
 		return;

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -148,6 +148,7 @@ function SubmitClicked()
 end
 
 function binarySearchNumberInArray(arr, n, l, r)
+	if #arr == 0 then return false; end
 	if l == nil or r == nil then
 		l = 1;
 		r = #arr;

--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -153,4 +153,6 @@ function SubmitClicked()
 	for i, v in pairs(requestNewTerritoryButton) do
 		print(i, v);
 	end
+	local func = requestNewTerritoryButton.GetOnClick();
+	if func ~= nil then func(); end
 end

--- a/BuyNeutralMod/Server_AdvanceTurn.lua
+++ b/BuyNeutralMod/Server_AdvanceTurn.lua
@@ -30,6 +30,8 @@ function Server_AdvanceTurn_Order(game, order, result, skipThisOrder, addNewOrde
 		--All checks passed!  Let's change ownership
 		local mod = WL.TerritoryModification.Create(targetTerritoryID);
 		mod.SetOwnerOpt = order.PlayerID;
-		addNewOrder(WL.GameOrderEvent.Create(order.PlayerID, "Purchased " .. game.Map.Territories[targetTerritoryID].Name, {}, {mod}));
+		local event = WL.GameOrderEvent.Create(order.PlayerID, "Purchased " .. game.Map.Territories[targetTerritoryID].Name, {}, {mod});
+		event.JumpToActionSpotOpt = WL.RectangleVM.Create(game.Map.Territories[targetTerritoryID].MiddlePointX, game.Map.Territories[targetTerritoryID].MiddlePointY, game.Map.Territories[targetTerritoryID].MiddlePointX, game.Map.Territories[targetTerritoryID].MiddlePointY);
+		addNewOrder(event, true);
 	end
 end

--- a/BuyNeutralMod/Utilities.lua
+++ b/BuyNeutralMod/Utilities.lua
@@ -61,3 +61,17 @@ end
 function startsWith(str, sub)
 	return string.sub(str, 1, string.len(sub)) == sub;
 end
+
+function valueInTable(arr, v)
+	for _, v2 in pairs(arr) do
+		if v == v2 then return true; end
+	end
+	return false;
+end
+
+function printArray(arr)
+	for i, v in ipairs(arr) do
+		print(i, v);
+	end
+end
+


### PR DESCRIPTION
I've send you the summary already in Warzone, but I'll add it here too for those that cannot see it.


-**Updated territory selecting**
This was the main reason for me to update the mod. It was using an list of territory names from which the player had to choose from. Now it requires the player to pick a territory from the map with a few constraints: Cannot be a territory the player owns, cannot be a territory another player owns, cannot be a territory that is not fully visible (completely fogged or when you can only see the owner of it), cannot be a territory you already made a purchase order for and cannot be a territory that has a special unit. For the latter two I'll go into a bit more detail later.
-**Improved UI (imo)**
I added some color to the UI and some more detail. There's now also a red-ish text that will pop up when you select a territory that does not meet one of the requirements listed in the previous point. And also it is kind of my signature leaving behind a colored UI :). You can remove it if you don't like it or change the color of it, I don't mind.
-**Added shortcut in the purchase menu**
You can now open the menu using the purchase menu. It has a short description and a button that redirects the player to the actual, normal and exact same menu as if they opened the menu using the old way (via the green game button).
-**Fixed order in place**
Purchase orders now created by the mod will be fixated in a specific phase. I chose the Purchase phase because it seems to me it the most appropiate one. So now the orders don't always end up as the last order and they can not be moved out of their phase when trying to move them up and down.
-**Added view movement**
Lastly, I added something in the Advance_Turn hook. Now when creating an event order when a purchase order is processed, it will give it a view of the event territory that was bought.

These are the most significant changes I made. I tried to keep everything the same, but I did needed to revamp almost the whole UI. And if any problems arise, you can just redirect the errors to me, I'm totally fine with that.

Quickly about the 2 new requirements I added, I felt like they were needed.
Creating a second purchase order for the same territory is pretty much pointless, even more now with the orders being fixed in place at the very start of the turn. It is easy to miss that you've already created a purchase order for that territory, so I disallow them from creating a second order for it.
Now with custom special units, we need to take into account that mods might place them on neutral territories or that they end up on neutral territories via other ways. Removing them or even setting the owner of the territory to a non-neutral might break the other mod(s). Besides, we only define the price per army on the territory, we do not allow the player to define a price for special units.

`<br>`
**Template**
[Template](https://www.warzone.com/SinglePlayer?TemplateID=1507729)
I've created a little template to test the changes out. Quick note that anything related to the dragons mod is purely there to show that you cannot purchase a territory with a special unit. So any pop up or menu it might have, just leave them and click them away.

**Test game**
[Multiplayer Game](https://www.warzone.com/MultiPlayer?GameID=36057587)
This is a little test game I did with some testers. Note that I was developing the mod further while the game was in progress, so not every turn might have all the updates listed above.