### PR TITLE
Temporary Bug Fix

### DIFF
--- a/BuyNeutralMod/Client_PresentMenuUI.lua
+++ b/BuyNeutralMod/Client_PresentMenuUI.lua
@@ -20,6 +20,13 @@ function Client_PresentMenuUI(rootParent, setMaxSize, setScrollable, game)
 		return;
 	end
 
+	-- It is possible to open the menu in No Luck Cycle, manual distribution
+	-- Meaning that the `LatestStanding` is not initialized yet?
+	if (game.LatestStanding == nil) then
+		UI.CreateLabel(vert).SetText("You cannot use the mod currently, something is not right");
+		return;
+	end
+
 	showMain();
 end
 


### PR DESCRIPTION
With No Luck cycle + manual distribution it is possible to open up the menu BEFORE you press [start] button.  Then `LatestStanding` is not initialized, and possibly other fields as well. At least this menu crashes when it happens, but it very well be the case that more mods will crash under the same circumstances