### PR TITLE
Randomized Starting Cities mod is overriding existing structures

### DIFF
--- a/RandomStartingCitiesMod/DistributeCities.lua
+++ b/RandomStartingCitiesMod/DistributeCities.lua
@@ -19,7 +19,13 @@ function DistributeCities(game, standing)
     --Then loop up to the number of territories we need to distribute on
     for i=1,numTerrs do
         local s = terrs[i].Structures;
-        if (s == nil) then s = {}; end;
+        if (s == nil) then 
+            s = {}; 
+        else        -- If we do not copy the existing structures to the new structures table, they will get overridden
+            for struct, num in pairs(s) do
+                s[struct] = num;
+            end
+        end
         s[WL.StructureType.City] = Mod.Settings.NumCitiesPerTerritory;
         terrs[i].Structures = s;
     end


### PR DESCRIPTION
We need to explicitly copy all existing structures into the new/modified structures table in order to maintain mod compatibility. I encountered cases where the mod was overriding structures added by other mods.